### PR TITLE
Support metadata in EpisodicNode

### DIFF
--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -17,11 +17,10 @@ limitations under the License.
 import logging
 from datetime import datetime
 from time import time
-from typing_extensions import Any
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
-from typing_extensions import LiteralString
+from typing_extensions import Any, LiteralString
 
 from graphiti_core.cross_encoder.client import CrossEncoderClient
 from graphiti_core.cross_encoder.openai_reranker_client import OpenAIRerankerClient
@@ -617,7 +616,7 @@ class Graphiti:
                 for episode in bulk_episodes
             ]
 
-            for raw_ep, ep in zip(bulk_episodes, episodes):
+            for raw_ep, ep in zip(bulk_episodes, episodes, strict=False):
                 if raw_ep.uuid is not None and raw_ep.metadata is not None:
                     ep.metadata.update(raw_ep.metadata)
 

--- a/graphiti_core/graphiti.py
+++ b/graphiti_core/graphiti.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from datetime import datetime
 from time import time
+from typing_extensions import Any
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
@@ -351,6 +352,7 @@ class Graphiti:
         episode_body: str,
         source_description: str,
         reference_time: datetime,
+        metadata: dict[str, Any] | None = None,
         source: EpisodeType = EpisodeType.message,
         group_id: str = '',
         uuid: str | None = None,
@@ -377,6 +379,8 @@ class Graphiti:
             A description of the episode's source.
         reference_time : datetime
             The reference time for the episode.
+        metadata : dict[str, Any] | None
+            Optional. Custom metadata to store on the Episodic node.
         source : EpisodeType, optional
             The type of the episode. Defaults to EpisodeType.message.
         group_id : str | None
@@ -447,8 +451,12 @@ class Graphiti:
                     source_description=source_description,
                     created_at=now,
                     valid_at=reference_time,
+                    metadata=metadata or {},
                 )
             )
+
+            if uuid is not None and metadata is not None:
+                episode.metadata.update(metadata)
 
             # Create default edge type map
             edge_type_map_default = (
@@ -604,9 +612,14 @@ class Graphiti:
                     group_id=group_id,
                     created_at=now,
                     valid_at=episode.reference_time,
+                    metadata=episode.metadata or {},
                 )
                 for episode in bulk_episodes
             ]
+
+            for raw_ep, ep in zip(bulk_episodes, episodes):
+                if raw_ep.uuid is not None and raw_ep.metadata is not None:
+                    ep.metadata.update(raw_ep.metadata)
 
             episodes_by_uuid: dict[str, EpisodicNode] = {
                 episode.uuid: episode for episode in episodes

--- a/graphiti_core/models/nodes/node_db_queries.py
+++ b/graphiti_core/models/nodes/node_db_queries.py
@@ -15,17 +15,14 @@ limitations under the License.
 """
 
 EPISODIC_NODE_SAVE = """
-        MERGE (n:Episodic {uuid: $uuid})
-        SET n = {uuid: $uuid, name: $name, group_id: $group_id, source_description: $source_description, source: $source, content: $content, 
-        entity_edges: $entity_edges, created_at: $created_at, valid_at: $valid_at}
+        MERGE (n:Episodic {uuid: $episode_data.uuid})
+        SET n = $episode_data
         RETURN n.uuid AS uuid"""
 
 EPISODIC_NODE_SAVE_BULK = """
     UNWIND $episodes AS episode
     MERGE (n:Episodic {uuid: episode.uuid})
-    SET n = {uuid: episode.uuid, name: episode.name, group_id: episode.group_id, source_description: episode.source_description, 
-        source: episode.source, content: episode.content, 
-    entity_edges: episode.entity_edges, created_at: episode.created_at, valid_at: episode.valid_at}
+    SET n = episode
     RETURN n.uuid AS uuid
 """
 

--- a/graphiti_core/utils/bulk_utils.py
+++ b/graphiti_core/utils/bulk_utils.py
@@ -63,6 +63,7 @@ class RawEpisode(BaseModel):
     source_description: str
     source: EpisodeType
     reference_time: datetime
+    metadata: dict[str, Any] | None = None
 
 
 async def retrieve_previous_episodes_bulk(
@@ -118,6 +119,7 @@ async def add_nodes_and_edges_bulk_tx(
     episodes = [dict(episode) for episode in episodic_nodes]
     for episode in episodes:
         episode['source'] = str(episode['source'].value)
+        episode.pop('labels', None)
     nodes: list[dict[str, Any]] = []
     for node in entity_nodes:
         if node.name_embedding is None:

--- a/tests/unit/test_episode_metadata.py
+++ b/tests/unit/test_episode_metadata.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timezone
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "bulk_utils", str(Path(__file__).resolve().parents[2] / "graphiti_core/utils/bulk_utils.py")
+)
+bulk_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bulk_utils)
+RawEpisode = bulk_utils.RawEpisode
+
+spec_node = importlib.util.spec_from_file_location(
+    "nodes", str(Path(__file__).resolve().parents[2] / "graphiti_core/nodes.py")
+)
+nodes = importlib.util.module_from_spec(spec_node)
+spec_node.loader.exec_module(nodes)
+EpisodicNode = nodes.EpisodicNode
+EpisodeType = nodes.EpisodeType
+
+
+def test_raw_episode_metadata_preserved():
+    meta = {"foo": "bar"}
+    raw = RawEpisode(
+        name="ep1",
+        content="content",
+        source_description="src",
+        source=EpisodeType.text,
+        reference_time=datetime.now(timezone.utc),
+        metadata=meta,
+    )
+    assert raw.metadata == meta
+
+    node = EpisodicNode(
+        name=raw.name,
+        group_id="g",
+        labels=[],
+        source=raw.source,
+        content=raw.content,
+        source_description=raw.source_description,
+        created_at=raw.reference_time,
+        valid_at=raw.reference_time,
+        metadata=raw.metadata,
+    )
+    assert node.metadata == meta

--- a/tests/unit/test_episode_metadata.py
+++ b/tests/unit/test_episode_metadata.py
@@ -1,22 +1,7 @@
 from datetime import datetime, timezone
 
-import importlib.util
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    "bulk_utils", str(Path(__file__).resolve().parents[2] / "graphiti_core/utils/bulk_utils.py")
-)
-bulk_utils = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(bulk_utils)
-RawEpisode = bulk_utils.RawEpisode
-
-spec_node = importlib.util.spec_from_file_location(
-    "nodes", str(Path(__file__).resolve().parents[2] / "graphiti_core/nodes.py")
-)
-nodes = importlib.util.module_from_spec(spec_node)
-spec_node.loader.exec_module(nodes)
-EpisodicNode = nodes.EpisodicNode
-EpisodeType = nodes.EpisodeType
+from graphiti_core.nodes import EpisodeType, EpisodicNode
+from graphiti_core.utils.bulk_utils import RawEpisode
 
 
 def test_raw_episode_metadata_preserved():


### PR DESCRIPTION
## Summary
- add metadata field to `RawEpisode`
- persist metadata on Episodic nodes
- expose metadata in database queries
- allow metadata in `add_episode` and `add_episode_bulk`
- add unit test for metadata handling

## Testing
- `pytest -q tests/unit/test_episode_metadata.py` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_6878f759986c8333a5bc0a8ec3cdf657