### PR TITLE
Add JinaAI reranker client

### DIFF
--- a/graphiti_core/cross_encoder/__init__.py
+++ b/graphiti_core/cross_encoder/__init__.py
@@ -16,5 +16,10 @@ limitations under the License.
 
 from .client import CrossEncoderClient
 from .openai_reranker_client import OpenAIRerankerClient
+from .jina_reranker_client import JinaAIRerankerClient
 
-__all__ = ['CrossEncoderClient', 'OpenAIRerankerClient']
+__all__ = [
+    'CrossEncoderClient',
+    'OpenAIRerankerClient',
+    'JinaAIRerankerClient',
+]

--- a/graphiti_core/cross_encoder/jina_reranker_client.py
+++ b/graphiti_core/cross_encoder/jina_reranker_client.py
@@ -1,0 +1,62 @@
+"""
+Jina AI Reranker Client
+"""
+
+from __future__ import annotations
+
+import os
+import httpx
+
+from .client import CrossEncoderClient
+
+DEFAULT_MODEL = "jina-reranker-m0"
+DEFAULT_BASE_URL = "https://api.jina.ai"
+
+
+class JinaAIRerankerConfig:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = DEFAULT_MODEL,
+        base_url: str = DEFAULT_BASE_URL,
+    ) -> None:
+        self.api_key = api_key or os.getenv("JINAAI_API_KEY")
+        self.model = model
+        self.base_url = base_url
+
+
+class JinaAIRerankerClient(CrossEncoderClient):
+    def __init__(
+        self,
+        config: JinaAIRerankerConfig | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if config is None:
+            config = JinaAIRerankerConfig()
+        self.config = config
+        if client is None:
+            self.client = httpx.AsyncClient(base_url=self.config.base_url)
+        else:
+            self.client = client
+
+    async def rank(self, query: str, passages: list[str]) -> list[tuple[str, float]]:
+        if not passages:
+            return []
+
+        payload = {
+            "model": self.config.model,
+            "query": query,
+            "top_n": len(passages),
+            "documents": [{"text": p} for p in passages],
+            "return_documents": False,
+        }
+        headers = {"Authorization": f"Bearer {self.config.api_key}"}
+        response = await self.client.post("/v1/rerank", json=payload, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        results = [
+            (passages[item["index"]], float(item["relevance_score"]))
+            for item in data.get("results", [])
+        ]
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results

--- a/tests/cross_encoder/test_jina_reranker_client.py
+++ b/tests/cross_encoder/test_jina_reranker_client.py
@@ -1,0 +1,69 @@
+"""
+Tests for JinaAIRerankerClient
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graphiti_core.cross_encoder.jina_reranker_client import (
+    JinaAIRerankerClient,
+    JinaAIRerankerConfig,
+)
+
+
+@pytest.fixture
+def mock_httpx_client():
+    with patch('httpx.AsyncClient') as mock_client:
+        instance = mock_client.return_value
+        instance.post = AsyncMock()
+        yield instance
+
+
+@pytest.fixture
+def jina_reranker_client(mock_httpx_client):
+    config = JinaAIRerankerConfig(api_key='test')
+    client = JinaAIRerankerClient(config=config)
+    client.client = mock_httpx_client
+    return client
+
+
+@pytest.fixture
+def mock_httpx_response() -> MagicMock:
+    mock_result = MagicMock()
+    mock_result.json.return_value = {
+        'results': [
+            {'index': 0, 'relevance_score': 0.9},
+            {'index': 1, 'relevance_score': 0.7},
+        ]
+    }
+    mock_result.raise_for_status = MagicMock()
+    return mock_result
+
+
+@pytest.mark.asyncio
+async def test_rank_basic_functionality(jina_reranker_client, mock_httpx_client, mock_httpx_response):
+    mock_httpx_client.post.return_value = mock_httpx_response
+
+    query = 'What is the capital of France?'
+    passages = [
+        'Paris is the capital of France.',
+        'Berlin is the capital of Germany.',
+    ]
+
+    result = await jina_reranker_client.rank(query, passages)
+
+    mock_httpx_client.post.assert_called_once()
+    _, kwargs = mock_httpx_client.post.call_args
+    assert kwargs['json']['query'] == query
+    assert kwargs['json']['documents'] == [{'text': passages[0]}, {'text': passages[1]}]
+
+    assert result[0][0] == passages[0]
+    assert result[0][1] == 0.9
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_rank_empty_input(jina_reranker_client):
+    result = await jina_reranker_client.rank('Empty', [])
+    assert result == []


### PR DESCRIPTION
## Summary
- add `JinaAIRerankerClient` using JinaAI's rerank API
- expose new client in `graphiti_core.cross_encoder`
- test JinaAI reranker client

## Testing
- `pytest tests/cross_encoder/test_jina_reranker_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ce69c6708333ad08e457a0cc795f